### PR TITLE
handle errors returned by the geonetwork POST /rest/records entrypoint

### DIFF
--- a/geonetwork/gn_api.py
+++ b/geonetwork/gn_api.py
@@ -90,7 +90,15 @@ class GnApi:
         resp.raise_for_status()
         results = resp.json()
         if results["errors"]:
-            raise ParameterException({"code": 404, "details": results["errors"]})
+            clean_error_stack = [
+                {
+                    **err,
+                    "stack": err["stack"].split("\n")
+                }
+                for err in results["errors"]
+            ]
+
+            raise ParameterException({"code": 404, "details": clean_error_stack})
 
         # take first id of results ids
         serial_id = next(iter(results["metadataInfos"].keys()))

--- a/geonetwork/gn_api.py
+++ b/geonetwork/gn_api.py
@@ -93,7 +93,7 @@ class GnApi:
             clean_error_stack = [
                 {
                     **err,
-                    "stack": err["stack"].split("\n")
+                    "stack": [t.replace("\t", "    ") for t in err["stack"].split("\n")]
                 }
                 for err in results["errors"]
             ]

--- a/geonetwork/gn_api.py
+++ b/geonetwork/gn_api.py
@@ -93,7 +93,7 @@ class GnApi:
             clean_error_stack = [
                 {
                     **err,
-                    "stack": [t.replace("\t", "    ") for t in err["stack"].split("\n")]
+                    "stack": [t.replace("\t", "    ") for t in err.get("stack", []).split("\n")]
                 }
                 for err in results["errors"]
             ]
@@ -101,7 +101,7 @@ class GnApi:
             raise ParameterException({"code": 404, "details": clean_error_stack})
 
         # take first id of results ids
-        serial_id = next(iter(results["metadataInfos"].keys()))
+        serial_id = next(iter(results["metadataInfos"].values()))["uuid"]
         metadata_json = self.session.get(
             f"{self.api_url}/records/{serial_id}",
             headers={"accept": "application/json"},

--- a/geonetwork/gn_api.py
+++ b/geonetwork/gn_api.py
@@ -88,7 +88,21 @@ class GnApi:
             },
         )
         resp.raise_for_status()
-        return resp.json()
+        results = resp.json()
+        if results["errors"]:
+            raise ParameterException({"code": 404, "details": results["errors"]})
+
+        # take first id of results ids
+        serial_id = next(iter(results["metadataInfos"].keys()))
+        metadata_json = self.session.get(
+            f"{self.api_url}/records/{serial_id}",
+            headers={"accept": "application/json"},
+        ).json()
+        uuid = metadata_json["gmd:fileIdentifier"]["gco:CharacterString"]["#text"]
+        return {
+            "msg": f"Metadata creation successful ({uuid})",
+            "detail": results,
+        }
 
     def get_metadataxml(self, uuid):
         headers = {

--- a/tests/test_gn_api.py
+++ b/tests/test_gn_api.py
@@ -83,7 +83,7 @@ def test_upload_zip(init_gn):
             assert 'multipart/form-data' in request.headers.get("Content-Type")
             assert "application/zip" in request.text
             assert "dummy_zip" in request.text
-            return {"errors": [], "metadataInfos": {101: {}}}
+            return {"errors": [], "metadataInfos": {101: {"uuid": 101}}}
         m.post('http://geonetwork/api/records', json=creation_callback)
 
         def record_callback(request, context):

--- a/tests/test_gn_api.py
+++ b/tests/test_gn_api.py
@@ -112,10 +112,18 @@ def test_upload_zip_fail(init_gn):
             assert 'multipart/form-data' in request.headers.get("Content-Type")
             assert "application/zip" in request.text
             assert "dummy_zip" in request.text
-            return {"errors": ["err1", "err2"]}
+            return {
+                "errors": [
+                    {"message": "err1", "stack": "line1\nline2"},
+                    {"message": "err2", "stack": "e2/line1\ne2/line2"},
+                ]
+            }
         m.post('http://geonetwork/api/records', json=record_callback)
         zipdata = BytesIO(b"dummy_zip")
         with pytest.raises(ParameterException) as err:
             init_gn.put_record_zip(zipdata)
         assert err.value.args[0]["code"] == 404
-        assert err.value.args[0]["details"] == ["err1", "err2"]
+        assert err.value.args[0]["details"] == [
+            {"message": "err1", "stack": ["line1", "line2"]},
+            {"message": "err2", "stack": ["e2/line1", "e2/line2"]},
+        ]

--- a/tests/test_gn_api.py
+++ b/tests/test_gn_api.py
@@ -115,7 +115,7 @@ def test_upload_zip_fail(init_gn):
             return {
                 "errors": [
                     {"message": "err1", "stack": "line1\nline2"},
-                    {"message": "err2", "stack": "e2/line1\ne2/line2"},
+                    {"message": "err2", "stack": "e2/line1\n\tat e2/line2"},
                 ]
             }
         m.post('http://geonetwork/api/records', json=record_callback)
@@ -125,5 +125,5 @@ def test_upload_zip_fail(init_gn):
         assert err.value.args[0]["code"] == 404
         assert err.value.args[0]["details"] == [
             {"message": "err1", "stack": ["line1", "line2"]},
-            {"message": "err2", "stack": ["e2/line1", "e2/line2"]},
+            {"message": "err2", "stack": ["e2/line1", "    at e2/line2"]},
         ]

--- a/tests/test_gn_api.py
+++ b/tests/test_gn_api.py
@@ -76,6 +76,35 @@ def test_record_zip_unknown_uuid(init_gn):
 def test_upload_zip(init_gn):
     with requests_mock.Mocker() as m:
 
+        def creation_callback(request, context):
+            assert request.headers.get("accept") == "application/json"
+            assert request.headers.get('Content-Length') == '184'
+            assert request.headers.get('X-XSRF-TOKEN') == "dummy_xsrf"
+            assert 'multipart/form-data' in request.headers.get("Content-Type")
+            assert "application/zip" in request.text
+            assert "dummy_zip" in request.text
+            return {"errors": [], "metadataInfos": {101: {}}}
+        m.post('http://geonetwork/api/records', json=creation_callback)
+
+        def record_callback(request, context):
+            assert request.headers.get("accept") == "application/json"
+            assert request.headers.get('X-XSRF-TOKEN') == "dummy_xsrf"
+            return {
+                "gmd:fileIdentifier": {
+                    "gco:CharacterString": {
+                        "#text": "pseuso_uuid-1234-55ac"
+                    }
+                }
+            }
+        m.get('http://geonetwork/api/records/101', json=record_callback)
+        zipdata = BytesIO(b"dummy_zip")
+        resp = init_gn.put_record_zip(zipdata)
+        assert resp["msg"] == "Metadata creation successful (pseuso_uuid-1234-55ac)"
+
+
+def test_upload_zip_fail(init_gn):
+    with requests_mock.Mocker() as m:
+
         def record_callback(request, context):
             assert request.headers.get("accept") == "application/json"
             assert request.headers.get('Content-Length') == '184'
@@ -83,7 +112,10 @@ def test_upload_zip(init_gn):
             assert 'multipart/form-data' in request.headers.get("Content-Type")
             assert "application/zip" in request.text
             assert "dummy_zip" in request.text
-            return {"created": "success"}
+            return {"errors": ["err1", "err2"]}
         m.post('http://geonetwork/api/records', json=record_callback)
         zipdata = BytesIO(b"dummy_zip")
-        init_gn.put_record_zip(zipdata)
+        with pytest.raises(ParameterException) as err:
+            init_gn.put_record_zip(zipdata)
+        assert err.value.args[0]["code"] == 404
+        assert err.value.args[0]["details"] == ["err1", "err2"]


### PR DESCRIPTION
Implementation of logics to recognize error condition in the response from geonetwork API post record call.

All details of the error detection are handled in this lib, the parent app will only handle the ParamException