### PR TITLE
Add publish and unpublish endpoints

### DIFF
--- a/geonetwork/gn_api.py
+++ b/geonetwork/gn_api.py
@@ -242,5 +242,31 @@ class GnApi:
         raise_for_status(resp, exception_class=GnElasticException)
         return resp.json()
 
+    def put_publish_record(self, uuid: str) -> Any:
+        """
+        Publish a metadata record
+        :param uuid: uuid of the metadata to publish
+        :returns: response from the API
+        """
+        url = f"{self.api_url}/records/{uuid}/publish"
+        resp = self.session.put(url)
+        raise_for_status(resp)
+        if resp.content:
+            return resp.json()
+        return {"msg": "Metadata published successfully", "uuid": uuid}
+
+    def put_unpublish_record(self, uuid: str) -> Any:
+        """
+        Unpublish a metadata record
+        :param uuid: uuid of the metadata to unpublish
+        :returns: response from the API
+        """
+        url = f"{self.api_url}/records/{uuid}/unpublish"
+        resp = self.session.put(url)
+        raise_for_status(resp)
+        if resp.content:
+            return resp.json()
+        return {"msg": "Metadata unpublished successfully", "uuid": uuid}
+
     def close_session(self):
         self.session.close()


### PR DESCRIPTION
This pull request adds two new methods to the `gn_api.py` API client to support publishing and unpublishing metadata records. These changes extend the API's functionality, allowing users to programmatically change the publication status of records.

New API endpoints for record publication management:

* Added `put_publish_record` method to publish a metadata record by UUID, sending a PUT request to the `/records/{uuid}/publish` endpoint.
* Added `put_unpublish_record` method to unpublish a metadata record by UUID, sending a PUT request to the `/records/{uuid}/unpublish` endpoint.